### PR TITLE
🌵 chei theia no longer default, switch to vscode. update argo 2.7.2 🌵

### DIFF
--- a/docs/2-platform-work/2-argocd.md
+++ b/docs/2-platform-work/2-argocd.md
@@ -72,7 +72,7 @@ ArgoCD is a gitops controller. We will use the OpenShift Gitops operator to depl
 7. Setup our ArgoCD configuration. There is quite a bit of detail here. We configure the [ArgoCD Vault Plugin](https://github.com/argoproj-labs/argocd-vault-plugin) so that we can integrate our secrets' management with ArgoCD.
 
    ```bash
-   export IMAGE_TAG=2.6.7
+   export IMAGE_TAG=2.7.2
    ```
 
    ```yaml

--- a/docs/config/all.json
+++ b/docs/config/all.json
@@ -1,3 +1,3 @@
 {
-    "devfile411": "https://raw.githubusercontent.com/opendatahub-io-contrib/data-mesh-pattern/main/docs/stack/devfile-v2-data-mesh.yaml?che-editor=eclipse/che-theia/latest"
+    "devfile411": "https://raw.githubusercontent.com/opendatahub-io-contrib/data-mesh-pattern/main/docs/stack/devfile-v2-data-mesh.yaml?che-editor=che-incubator/che-code/latest"
 }


### PR DESCRIPTION
che-theia removed - vscode is now default - https://github.com/eclipse-che/che-operator/pull/1551
update argocd v2.7.2